### PR TITLE
container: Work around bug in Ubuntu dhclient

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -40,6 +40,9 @@ impl Container {
 
         lxc(&["launch", base, &full_name, "-e", "-n", "lxdbr0"])?;
 
+        // XXX: https://bugzilla.redhat.com/show_bug.cgi?id=1419315
+        lxc(&["exec", &full_name, "--mode=non-interactive", "-n", "--", "touch", "/etc/fstab"])?;
+
         // Hack to wait for network up and running
         lxc(&["exec", &full_name, "--mode=non-interactive", "-n", "--", "dhclient"])?;
 
@@ -80,6 +83,9 @@ impl Container {
         lxc(&["launch", base, &full_name, "-e", "-n", "lxdbr0",
             "-c", "security.privileged=true",
             "-c", "raw.lxc=lxc.apparmor.profile=unconfined"])?;
+
+        // XXX: https://bugzilla.redhat.com/show_bug.cgi?id=1419315
+        lxc(&["exec", &full_name, "--mode=non-interactive", "-n", "--", "touch", "/etc/fstab"])?;
 
         // Hack to wait for network up and running
         lxc(&["exec", &full_name, "--mode=non-interactive", "-n", "--", "dhclient"])?;


### PR DESCRIPTION
dhclient will unconditionally check fstab and get stuck in a loop. Work
around the issue by touching the file to ensure it exists.

Test by running the LXC commands directly:

```
sudo lxc launch ubuntu:22.04 test-01 -e -n lxdbr0
# Without this, dhclient hangs until the container is stopped.
sudo lxc exec test-01 --mode=non-interactive -n -- touch /etc/fstab
sudo lxc exec test-01 --mode=non-interactive -n -- dhclient
```

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1419315