### PR TITLE
Update edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "lxd"
 version = "0.1.8"
+edition = "2021"
 authors = ["Jeremy Soller <jackpot51@gmail.com>"]
 description = "A Rust library for controlling LXD"
 documentation = "https://docs.rs/lxd"
@@ -13,8 +14,7 @@ name = "lxd"
 path = "src/lib.rs"
 
 [dependencies]
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [dev-dependencies]

--- a/src/container.rs
+++ b/src/container.rs
@@ -34,7 +34,7 @@ impl Container {
     /// ```
     pub fn new(location: Location, name: &str, base: &str) -> io::Result<Self> {
         let full_name = match location {
-            Location::Local => format!("{}", name),
+            Location::Local => name.to_string(),
             Location::Remote(remote) => format!("{}:{}", remote, name)
         };
 
@@ -73,7 +73,7 @@ impl Container {
     /// ```
     pub unsafe fn new_privileged(location: Location, name: &str, base: &str) -> io::Result<Self> {
         let full_name = match location {
-            Location::Local => format!("{}", name),
+            Location::Local => name.to_string(),
             Location::Remote(remote) => format!("{}:{}", remote, name)
         };
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,4 +1,4 @@
-use serde_json;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::io;
 

--- a/src/info.rs
+++ b/src/info.rs
@@ -1,4 +1,4 @@
-use serde_json;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::io;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,5 @@
 //! A Rust library for controlling LXD
 
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-
 use std::process::{Command, Stdio};
 use std::io;
 


### PR DESCRIPTION
- Update edition from 2015 to 2021
- Replace `serde_derive` with `derive` feature
- Fix `clippy::useless_format`