### PR TITLE
Remove execs into containers

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -40,12 +40,6 @@ impl Container {
 
         lxc(&["launch", base, &full_name, "-e", "-n", "lxdbr0"])?;
 
-        // XXX: https://bugzilla.redhat.com/show_bug.cgi?id=1419315
-        lxc(&["exec", &full_name, "--mode=non-interactive", "-n", "--", "touch", "/etc/fstab"])?;
-
-        // Hack to wait for network up and running
-        lxc(&["exec", &full_name, "--mode=non-interactive", "-n", "--", "dhclient"])?;
-
         Ok(Container {
             name: full_name
         })
@@ -83,12 +77,6 @@ impl Container {
         lxc(&["launch", base, &full_name, "-e", "-n", "lxdbr0",
             "-c", "security.privileged=true",
             "-c", "raw.lxc=lxc.apparmor.profile=unconfined"])?;
-
-        // XXX: https://bugzilla.redhat.com/show_bug.cgi?id=1419315
-        lxc(&["exec", &full_name, "--mode=non-interactive", "-n", "--", "touch", "/etc/fstab"])?;
-
-        // Hack to wait for network up and running
-        lxc(&["exec", &full_name, "--mode=non-interactive", "-n", "--", "dhclient"])?;
 
         Ok(Container {
             name: full_name


### PR DESCRIPTION
dhclient is not available by default in Ubuntu 24.04 images, causing buildchain to fail.

Remove all execs into the container, which assumes certain properties that may not be true or required.